### PR TITLE
docs: use non-expiring Discord invite

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -100,7 +100,7 @@ const config: Config = {
           position: 'right',
         },
         {
-          href: 'https://discord.gg/Q3bQSX8C',
+          href: 'https://discord.gg/xnkSWDmpXZ',
           label: 'Discord',
           position: 'right',
         },


### PR DESCRIPTION
Thank you @wolfmanfx for pointing out that the previous one expired. Seems to by default after 7 days. This new link should stay working now as I set it to not expire.
